### PR TITLE
PostgreSQL lib on Windows seems to have a different lib name libpq

### DIFF
--- a/pq.odin
+++ b/pq.odin
@@ -2,7 +2,11 @@ package pq
 
 import "core:c/libc"
 
-LIB :: #config(POSTGRES_LIB, "system:pq")
+when ODIN_OS == .Windows {
+	LIB :: #config(POSTGRES_LIB, "system:libpq.lib")
+} else {
+	LIB :: #config(POSTGRES_LIB, "system:pq")
+}
 
 foreign import pq { LIB }
 


### PR DESCRIPTION
PostgreSQL lib on Windows seems to have a different name (libpq), hence this  suggestion. I tested on Windows and WSL Linux